### PR TITLE
fix(curriculum): Inconsistent uses of "a" and "an" (#54915)

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc24073f86c76b9248c6ebb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc24073f86c76b9248c6ebb.md
@@ -15,7 +15,7 @@ Here is an example of an `img` element with a `src` attribute pointing to the fr
 <img src="https://cdn.freecodecamp.org/platform/universal/fcc_secondary.svg">
 ```
 
-Inside the existing `img` element, add an `src` attribute with this URL:
+Inside the existing `img` element, add a `src` attribute with this URL:
 
 `https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg`
 
@@ -27,7 +27,7 @@ Your code should have an `img` element. You may have removed the `img` element o
 assert(document.querySelector('img'));
 ```
 
-Your `img` element should have an `src` attribute. You have either omitted the attribute or have a typo. Make sure there is a space between the element name and the attribute name.
+Your `img` element should have a `src` attribute. You have either omitted the attribute or have a typo. Make sure there is a space between the element name and the attribute name.
 
 ```js
 assert(document.querySelector('img').src);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa30b9eacea3f48c6300ad.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa30b9eacea3f48c6300ad.md
@@ -21,7 +21,7 @@ Turn the image into a link by surrounding it with necessary element tags. Use `h
 
 # --hints--
 
-You should have an `img` element with an `src` value of `https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg`. You may have accidentally deleted it.
+You should have an `img` element with a `src` value of `https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg`. You may have accidentally deleted it.
 
 ```js
 assert(

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6250eacea3f48c6300b2.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-After the unordered list, add a new image with an `src` attribute value set to:
+After the unordered list, add a new image with a `src` attribute value set to:
 
 `https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg`
 
@@ -40,13 +40,13 @@ assert(
 );
 ```
 
-The new image does not have an `src` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
+The new image does not have a `src` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
 
 ```js
 assert($('section')[1].lastElementChild.hasAttribute('src'));
 ```
 
-The new image should have an `src` value of `https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg`. Make sure the `src` attribute's value is surrounded with quotation marks.
+The new image should have a `src` value of `https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg`. Make sure the `src` attribute's value is surrounded with quotation marks.
 
 ```js
 assert(

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efada803cbd2bbdab94e332.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efada803cbd2bbdab94e332.md
@@ -38,7 +38,7 @@ assert(
 );
 ```
 
-The third image should have an `src` attribute set to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/cats.jpg`.
+The third image should have a `src` attribute set to `https://cdn.freecodecamp.org/curriculum/cat-photo-app/cats.jpg`.
 
 ```js
 const catsImg = document.querySelectorAll('figure > img')[1];

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655dc43318591b975cdfe2d8.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/655dc43318591b975cdfe2d8.md
@@ -55,7 +55,7 @@ Your `allSongs` array should have an object with a `duration` property set to th
 assert.equal(allSongs[0].duration, "4:25");
 ```
 
-Your `allSongs` array should have an object with an `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/scratching-the-surface.mp3"`.
+Your `allSongs` array should have an object with a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/scratching-the-surface.mp3"`.
 
 ```js
 assert.equal(allSongs[0].src, "https://cdn.freecodecamp.org/curriculum/js-music-player/scratching-the-surface.mp3");

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65606d06666e118ba86162be.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65606d06666e118ba86162be.md
@@ -55,7 +55,7 @@ The second object in your `allSongs` array should have a `duration` property set
 assert.equal(allSongs[1].duration, "4:15");
 ```
 
-The second object in your `allSongs` array should have an `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3"`.
+The second object in your `allSongs` array should have a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3"`.
 
 ```js
 assert.equal(allSongs[1].src, "https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3");

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65606ed6ea2baca053327e9b.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-string-and-array-methods-by-building-a-music-player/65606ed6ea2baca053327e9b.md
@@ -49,7 +49,7 @@ The third object in your `allSongs` array should have a `duration` property set 
 assert.equal(allSongs[2].duration, "3:51");
 ```
 
-The third object in your `allSongs` array should have an `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3"`.
+The third object in your `allSongs` array should have a `src` property set to the string `"https://cdn.freecodecamp.org/curriculum/js-music-player/can't-stay-down.mp3"`.
 
 ```js
 assert.equal(allSongs[2].src, "https://cdn.freecodecamp.org/curriculum/js-music-player/still-learning.mp3");


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
